### PR TITLE
Test if there is error property in error object

### DIFF
--- a/as/example1/src/server.js
+++ b/as/example1/src/server.js
@@ -18,7 +18,7 @@ const NDID_API_CALLBACK_PORT = process.env.NDID_API_CALLBACK_PORT || 5003;
       });
       break;
     } catch (error) {
-      if (error.error.code === 25005) break;
+      if (error.error && error.error.code === 25005) break;
       console.error('Error setting callback URL at NDID API');
     }
     // simple wait


### PR DESCRIPTION
When error is thrown from fetch function, there is no `error` property causing the application to exit. 
To fix this, we test if there is `error` property in error object before reading `error.error.code`.