### PR TITLE
Update docker build scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,8 @@ FROM node:8-alpine
 
 ENV TERM=xterm-256color
 
+RUN apk update && apk add --no-cache bash openssl
+
 WORKDIR /examples
 
 COPY idp/example1 /examples/idp
@@ -26,7 +28,5 @@ COPY docker/start-node.sh /examples
 COPY --from=build /examples/idp/node_modules /examples/idp/node_modules
 COPY --from=build /examples/rp/node_modules /examples/rp/node_modules
 COPY --from=build /examples/as/node_modules /examples/as/node_modules
-
-RUN apk update && apk add --no-cache bash
 
 ENTRYPOINT ["./start-node.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,11 @@ COPY idp/example1/package*.json /examples/idp/
 COPY rp/example1/package*.json /examples/rp/
 COPY as/example1/package*.json /examples/as/
 
-RUN cd /examples/idp && npm install && \
+RUN apk update && apk add --virtual .build-deps python make g++ && \
+    cd /examples/idp && npm install && \
     cd /examples/rp && npm install && \
-    cd /examples/as && npm install
+    cd /examples/as && npm install && \
+    apk del .build-deps
 
 
 FROM node:8-alpine

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+BUILD_COMMIT=$(git log -1 --format=%H) BUILD_DATE=$(date) docker-compose -f $(dirname $0)/docker-compose.build.yml build $@

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -1,7 +1,10 @@
-version: "3"
+version: "3.3"
 services: 
   examples:
     build:
       context: ../
       dockerfile: docker/Dockerfile
+      labels:
+        build.commit: ${BUILD_COMMIT}
+        build.date: ${BUILD_DATE}
     image: ndidplatform/examples:latest

--- a/idp/example1/src/zkProof.js
+++ b/idp/example1/src/zkProof.js
@@ -73,7 +73,7 @@ export function calculateSecret(namespace, identifier,privateKey) {
 
 export function genNewKeyPair(sid) {
   let pathSid = './dev_user_key/' + sid;
-  let gen = spawnSync('ssh-keygen', ['-t', 'rsa', '-N', '', '-f', pathSid, '-b', '2048']);
+  let gen = spawnSync('openssl', ['genrsa', '-out', pathSid, '2048']);
   //console.log(gen.stderr.toString());
   let encode = spawnSync('openssl', ['rsa', '-in', pathSid, '-pubout', '-out', pathSid + '.pub']);
   //console.log(encode.stderr.toString());

--- a/idp/example1/src/zkProof.js
+++ b/idp/example1/src/zkProof.js
@@ -77,4 +77,8 @@ export function genNewKeyPair(sid) {
   //console.log(gen.stderr.toString());
   let encode = spawnSync('openssl', ['rsa', '-in', pathSid, '-pubout', '-out', pathSid + '.pub']);
   //console.log(encode.stderr.toString());
+
+  if (gen.status !== 0 || encode.status !== 0) {
+    throw new Error("Failed in genNewKeyPair()");
+  }
 }


### PR DESCRIPTION
- add labels: build.commit and build.date in docker images
- add build.sh for building docker images with labels
- add .dockerignore

[zk related]
- add openssl 
- generate private key using openssl instead of ssh-keygen
- throw error when keypairs generation is failed

[npm]
- add python, make, and g++ for building some npm modules