### PR TITLE
Fix: Obsolete python package on Node12-Alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ COPY rp/api_v5/example1/package*.json /examples/rp/
 COPY as/api_v5/example1/package*.json /examples/as/
 COPY external_crypto_service/example1/package*.json /examples/dpki/
 
-RUN apk update && apk add --no-cache --virtual .build-deps python make g++
+RUN apk update && apk add --no-cache --virtual .build-deps python3 make g++
 RUN cd /examples/idp && npm install && \
     cd /examples/rp && npm install && \
     cd /examples/as && npm install && \


### PR DESCRIPTION
As of 10 Feb 2022, Node12-Alpine use Alpine3.15 as a base distro.
However, the python package has been removed since Alpine3.5 and replace
with python2 and python3 package.
This will cause build error:

ERROR: unable to select packages:
  python (no such package):
    required by: .build-deps-20220209.171613[python]

This patch will apply python3 package.
Test has been perform in linux/amd64 and aarch64